### PR TITLE
fix: populate Slurm topology for HyperPod

### DIFF
--- a/hyperpod/lib/lambda/custom-resources/lifecycle-loader/index.py
+++ b/hyperpod/lib/lambda/custom-resources/lifecycle-loader/index.py
@@ -98,6 +98,35 @@ def upload_file_to_s3(
     )
 
 
+def upload_local_overrides(s3_client, bucket, bucket_path):
+    """Upload local lifecycle script overrides after the upstream scripts."""
+    overrides_dir = os.path.join(os.path.dirname(__file__), "overrides")
+    if not os.path.isdir(overrides_dir):
+        logger.info("No local lifecycle overrides found")
+        return
+
+    for root, _, files in os.walk(overrides_dir):
+        rel_dir = os.path.relpath(root, overrides_dir)
+        for file_name in files:
+            file_path = os.path.join(root, file_name)
+            if rel_dir == ".":
+                s3_key = file_name
+            else:
+                s3_key = f"{rel_dir}/{file_name}"
+
+            logger.info(f"Uploading local override {s3_key}")
+            with open(file_path, "rb") as f:
+                file_content = f.read()
+            upload_file_to_s3(
+                s3_client,
+                bucket,
+                bucket_path,
+                file_content,
+                s3_key,
+                determine_content_type(file_name),
+            )
+
+
 def download_github_file(download_url):
     """Download file content from GitHub."""
     file_req = urllib.request.Request(download_url)
@@ -226,6 +255,7 @@ def handle_create_update(event, context):
                     f"{path}/{dir_name}",
                     dir_name,
                 )
+        upload_local_overrides(s3, bucket, bucket_path)
         return True, "Files uploaded successfully"
 
     except s3.exceptions.NoSuchBucket:

--- a/hyperpod/lib/lambda/custom-resources/lifecycle-loader/overrides/ensure_topology_conf.sh
+++ b/hyperpod/lib/lambda/custom-resources/lifecycle-loader/overrides/ensure_topology_conf.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+set -euo pipefail
+
+ensure_topology_conf() {
+  local candidate_confs=()
+  local active_conf=""
+
+  if command -v scontrol >/dev/null 2>&1; then
+    active_conf="$(scontrol show config 2>/dev/null | awk -F= '/^SLURM_CONF/ { gsub(/[ \t]/, "", $2); print $2; exit }' || true)"
+    if [[ -n "${active_conf:-}" ]]; then
+      candidate_confs+=("${active_conf}")
+    fi
+  fi
+
+  candidate_confs+=("/opt/slurm/etc/slurm.conf")
+  while IFS= read -r conf; do
+    candidate_confs+=("${conf}")
+  done < <(find /opt -maxdepth 4 -path '/opt/slurm-*/etc/slurm.conf' -type f 2>/dev/null | sort)
+
+  local slurm_conf=""
+  for conf in "${candidate_confs[@]}"; do
+    if [[ -f "${conf}" ]] && grep -q '^TopologyPlugin=topology/tree' "${conf}" && grep -q '^NodeName=' "${conf}"; then
+      slurm_conf="${conf}"
+      break
+    fi
+  done
+
+  if [[ -z "${slurm_conf}" ]]; then
+    echo "[WARN] No Slurm config with topology/tree and NodeName entries found; skipping topology guard"
+    exit 0
+  fi
+
+  local topology_conf
+  topology_conf="$(dirname "${slurm_conf}")/topology.conf"
+
+  local nodes
+  nodes="$(awk '
+    /^NodeName=/ {
+      for (i = 1; i <= NF; i++) {
+        if ($i ~ /^NodeName=/) {
+          node = $i
+          sub(/^NodeName=/, "", node)
+          if (node != "DEFAULT") {
+            print node
+          }
+        }
+      }
+    }
+  ' "${slurm_conf}" | paste -sd, -)"
+
+  if [[ -z "${nodes}" ]]; then
+    echo "[WARN] No NodeName entries found in ${slurm_conf}; leaving ${topology_conf} unchanged"
+    exit 0
+  fi
+
+  local expected="SwitchName=switch0 Nodes=${nodes}"
+  if [[ -f "${topology_conf}" ]] && grep -qxF "${expected}" "${topology_conf}"; then
+    exit 0
+  fi
+
+  echo "[INFO] Writing ${topology_conf} for topology/tree from ${slurm_conf}: ${nodes}"
+  printf '%s\n' "${expected}" > "${topology_conf}.tmp"
+  mv "${topology_conf}.tmp" "${topology_conf}"
+  chown slurm:slurm "${topology_conf}" || true
+  chmod 600 "${topology_conf}" || true
+
+  if systemctl is-active --quiet slurmctld; then
+    scontrol reconfigure || echo "[WARN] scontrol reconfigure failed after topology.conf update"
+  fi
+}
+
+install_systemd_guard() {
+  local scripts_dir="/opt/slurm/etc/scripts"
+  local helper="${scripts_dir}/ensure_topology_conf.sh"
+
+  mkdir -p "${scripts_dir}"
+  cp "$0" "${helper}"
+  chmod +x "${helper}"
+
+  cat > /etc/systemd/system/slurm-topology-guard.service <<EOF
+[Unit]
+Description=Ensure Slurm topology.conf is populated
+
+[Service]
+Type=oneshot
+ExecStart=${helper} --run
+EOF
+
+  cat > /etc/systemd/system/slurm-topology-guard.path <<'EOF'
+[Unit]
+Description=Watch Slurm topology configuration
+
+[Path]
+PathChanged=/opt/slurm/etc/slurm.conf
+PathChanged=/opt/slurm/etc/topology.conf
+PathModified=/opt/slurm/etc
+PathChanged=/opt/slurm-24.11/etc/slurm.conf
+PathChanged=/opt/slurm-24.11/etc/topology.conf
+PathModified=/opt/slurm-24.11/etc
+PathChanged=/opt/slurm-25.11/etc/slurm.conf
+PathChanged=/opt/slurm-25.11/etc/topology.conf
+PathModified=/opt/slurm-25.11/etc
+Unit=slurm-topology-guard.service
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+  cat > /etc/systemd/system/slurm-topology-guard.timer <<'EOF'
+[Unit]
+Description=Periodically ensure Slurm topology.conf is populated
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=1min
+Unit=slurm-topology-guard.service
+
+[Install]
+WantedBy=timers.target
+EOF
+
+  systemctl daemon-reload
+  systemctl enable --now slurm-topology-guard.path
+  systemctl enable --now slurm-topology-guard.timer
+  systemctl start slurm-topology-guard.service || true
+}
+
+if [[ "${1:-}" == "--run" ]]; then
+  ensure_topology_conf
+else
+  install_systemd_guard
+fi

--- a/hyperpod/lib/lambda/custom-resources/lifecycle-loader/overrides/on_create.sh
+++ b/hyperpod/lib/lambda/custom-resources/lifecycle-loader/overrides/on_create.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -ex
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOG_FILE="/var/log/provision/provisioning.log"
+mkdir -p "/var/log/provision"
+touch "$LOG_FILE"
+
+logger() {
+  echo "$@" | tee -a "$LOG_FILE"
+}
+
+PROVISIONING_PARAMETERS_PATH="${SCRIPT_DIR}/provisioning_parameters.json"
+
+# Give systemd-resolved enough time to restart after HostAgent changes.
+sleep 30
+
+if [[ -z "${SAGEMAKER_RESOURCE_CONFIG_PATH:-}" ]]; then
+  logger "Env var SAGEMAKER_RESOURCE_CONFIG_PATH is unset, trying to read from default location path"
+  SAGEMAKER_RESOURCE_CONFIG_PATH="/opt/ml/config/resource_config.json"
+
+  if [[ ! -f "$SAGEMAKER_RESOURCE_CONFIG_PATH" ]]; then
+    logger "Env var SAGEMAKER_RESOURCE_CONFIG_PATH is unset and file does not exist: $SAGEMAKER_RESOURCE_CONFIG_PATH"
+    logger "Assume vanilla cluster setup, no scripts to run. Exiting."
+    exit 0
+  fi
+else
+  logger "env var SAGEMAKER_RESOURCE_CONFIG_PATH is set to: $SAGEMAKER_RESOURCE_CONFIG_PATH"
+  if [[ ! -f "$SAGEMAKER_RESOURCE_CONFIG_PATH" ]]; then
+    logger "Env var SAGEMAKER_RESOURCE_CONFIG_PATH is set and file does not exist: $SAGEMAKER_RESOURCE_CONFIG_PATH"
+    exit 1
+  fi
+fi
+
+logger "Running lifecycle_script.py with resourceConfig: $SAGEMAKER_RESOURCE_CONFIG_PATH, provisioning_parameters: $PROVISIONING_PARAMETERS_PATH"
+
+python3 -u "${SCRIPT_DIR}/lifecycle_script.py" \
+  -rc "$SAGEMAKER_RESOURCE_CONFIG_PATH" \
+  -pp "$PROVISIONING_PARAMETERS_PATH" > >(tee -a "$LOG_FILE") 2>&1
+
+exit_code=$?
+
+if [[ $exit_code -eq 0 ]]; then
+  logger "[INFO] Installing Slurm topology guard"
+  bash "${SCRIPT_DIR}/ensure_topology_conf.sh" 2>&1 | tee -a "$LOG_FILE"
+fi
+
+exit $exit_code


### PR DESCRIPTION
## Summary
- Replaces the downloaded HyperPod lifecycle entrypoint with a repo-owned `on_create.sh` override.
- Adds a separate `ensure_topology_conf.sh` helper that installs a small systemd guard when Slurm `topology/tree` is enabled.
- The guard discovers the active Slurm config path, writes the matching `topology.conf` from final `NodeName=` entries, and reconfigures `slurmctld` when active.

## Why
A fresh HyperPod deployment with a GPU worker can enable `TopologyPlugin=topology/tree` without a corresponding `topology.conf` on the Slurm controller. In that state, Slurm rejects job submissions with:

```text
sbatch: error: Batch job submission failed: Requested topology configuration is not available
```

The likely trigger is the recent HyperPod service-side rollout of automatic Slurm topology management. AWS announced on April 23, 2026 that HyperPod now automatically selects and continuously maintains Slurm topology configuration, and that topology-aware scheduling is enabled by default: https://aws.amazon.com/about-aws/whats-new/2026/04/amazon-sagemaker-hyperpod-automatic-slurm-topology/

This repository does not configure Slurm topology directly, and the downloaded HyperPod lifecycle scripts do not appear to create `topology.conf`. A clean deploy from commit `8dd3a27` reproduced the failure before any sample workload was involved, so this patch keeps the sample deployment compatible with the current HyperPod/Slurm behavior.

## Implementation Notes
The fix avoids dynamic string patching of the downloaded lifecycle script. The loader now downloads the upstream lifecycle scripts as before, then uploads local lifecycle overrides from `lifecycle-loader/overrides/`:

- `on_create.sh` mirrors the upstream entrypoint flow and runs `ensure_topology_conf.sh` after successful lifecycle setup.
- `ensure_topology_conf.sh` installs the persistent systemd service/path/timer and performs the topology file reconciliation.

## Final Clean-Deploy Validation
All validation below used `us-east-2` with one `ml.g6e.2xlarge` worker. The account has quota `1` for `ml.g6e.2xlarge for cluster usage`, so validation stacks were deployed sequentially from scratch.

### Commit `8dd3a27` fails on clean deploy
- Source: commit `8dd3a27`
- Stack: `PASKUpstreamTopo`
- Cluster: `pask-upstream-topo` / `7bi4x14hoogh`
- Worker: `ip-10-0-133-247`, `ml.g6e.2xlarge`, `NVIDIA L40S`
- Slurm config evidence:
  - `TopologyPlugin = topology/tree`
  - `SLURM_CONF = /opt/slurm-24.11/etc/slurm.conf`
  - no `topology.conf` present
- Job submission result:

```text
JOB1_SUBMIT_RC=1
JOB1_SUBMIT_OUT=sbatch: error: Batch job submission failed: Requested topology configuration is not available
RECONFIGURE_RC=0
JOB2_SUBMIT_RC=1
JOB2_SUBMIT_OUT=sbatch: error: Batch job submission failed: Requested topology configuration is not available
```

### PR fix: clean deploy succeeds
- Source: `fix/hyperpod-slurm-topology` at `c9b1d91`
- Stack: `PASKFixTopo`
- Cluster: `pask-fix-topo` / `erstluaysicm`
- Login: `ip-10-0-186-9`
- Controller: `ip-10-0-185-206`
- Worker: `ip-10-0-137-204`, `ml.g6e.2xlarge`, `NVIDIA L40S`
- Slurm config evidence:
  - `TopologyPlugin = topology/tree`
  - `SLURM_CONF = /opt/slurm-24.11/etc/slurm.conf`
  - `slurm-topology-guard.path` active
  - `slurm-topology-guard.timer` active
  - controller `/opt/slurm-24.11/etc/topology.conf`:

```text
SwitchName=switch0 Nodes=ip-10-0-137-204
```

- Guard log evidence on the controller:

```text
[INFO] Writing /opt/slurm-24.11/etc/topology.conf for topology/tree from /opt/slurm-24.11/etc/slurm.conf: ip-10-0-137-204
```

- Job submission result:

```text
JOB1_JOBID=1
1|wrap|COMPLETED|0:0|00:00:01|ip-10-0-137-204
1.batch|batch|COMPLETED|0:0|00:00:01|ip-10-0-137-204
ip-10-0-137-204
NVIDIA L40S, 46068 MiB
RECONFIGURE_RC=0
JOB2_JOBID=2
2|wrap|COMPLETED|0:0|00:00:00|ip-10-0-137-204
2.batch|batch|COMPLETED|0:0|00:00:00|ip-10-0-137-204
ip-10-0-137-204
NVIDIA L40S, 46068 MiB
```

## Local Validation
- `bash -n hyperpod/lib/lambda/custom-resources/lifecycle-loader/overrides/*.sh`
- `python3 -m py_compile hyperpod/lib/lambda/custom-resources/lifecycle-loader/index.py`
- `npm --prefix hyperpod run build`
- `cdk synth PASKFixTopo`
- `git diff --check`

