### PR TITLE
docs: add Korean documentation

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-日本語 | [English](./README.md)
+日本語 | [English](./README.md) | [한국어](./README.ko.md)
 
 # Physical AI Scaffolding Kit
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,20 @@
+[日本語](./README.ja.md) | [English](./README.md) | 한국어
+
+# Physical AI Scaffolding Kit
+
+이 repository는 [Physical AI Development Support Program by AWS Japan](https://aws.amazon.com/jp/blogs/news/aws-japan-physical-ai-development-support-program/)에서 소개된 sample repository입니다.
+
+이 repository에는 다음 sample이 포함되어 있습니다.
+
+## Environment Setup
+
+로컬 resource가 제한된 환경에서는 training을 빠르게 반복하는 일이 어려울 수 있습니다.
+Amazon SageMaker HyperPod는 generative AI model 구축에 필요한 undifferentiated heavy lifting을 줄이고, 충분한 resource를 사용해 model을 효율적으로 구축할 수 있게 해줍니다.
+
+1. [Amazon SageMaker HyperPod로 Slurm Cluster 구축하기](/hyperpod/README.ko.md)
+
+## Samples for Amazon SageMaker HyperPod
+
+1. [π0 Sample](samples/openpi-sample/README.ko.md)
+2. [NVIDIA Isaac GR00T Sample](/samples/gr00t/README.ko.md)
+3. [NVIDIA Isaac Lab Newton RL Sample](/samples/newton-rl/README.ko.md)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[日本語](./README.ja.md) | English
+[日本語](./README.ja.md) | English | [한국어](./README.ko.md)
 
 # Physical AI Scaffolding Kit
 

--- a/hyperpod/README.ja.md
+++ b/hyperpod/README.ja.md
@@ -1,4 +1,4 @@
-日本語 | [English](./README.md)
+日本語 | [English](./README.md) | [한국어](./README.ko.md)
 
 # Amazon SageMaker HyperPodを使ったSlurmクラスタの構築
 

--- a/hyperpod/README.ko.md
+++ b/hyperpod/README.ko.md
@@ -1,0 +1,16 @@
+[日本語](./README.ja.md) | [English](./README.md) | 한국어
+
+# Amazon SageMaker HyperPod로 Slurm Cluster 구축하기
+
+이 sample은 Amazon SageMaker HyperPod를 Slurm cluster로 사용하는 environment를 구축하는 방법을 보여줍니다.
+
+## Architecture
+
+Node 간 shared storage로 [Amazon FSx for Lustre](https://aws.amazon.com/ko/fsx/lustre/)를 사용합니다. Lustre는 [S3 bucket과 linked data repository로 연결](https://docs.aws.amazon.com/fsx/latest/LustreGuide/create-dra-linked-data-repo.html)되어 저장된 data에 쉽게 접근할 수 있습니다.
+
+![Architecture](/hyperpod/docs/architecture.png)
+
+## Table of Contents
+
+1. [Deployment](/hyperpod/docs/ko/DEPLOYMENT.md)
+1. [Cleanup](/hyperpod/docs/ko/CLEANUP.md)

--- a/hyperpod/README.md
+++ b/hyperpod/README.md
@@ -1,4 +1,4 @@
-[日本語](./README.ja.md) | English
+[日本語](./README.ja.md) | English | [한국어](./README.ko.md)
 
 # Building a Slurm Cluster with Amazon SageMaker HyperPod
 

--- a/hyperpod/docs/ko/CLEANUP.md
+++ b/hyperpod/docs/ko/CLEANUP.md
@@ -1,0 +1,25 @@
+# Cleanup
+
+Environment가 더 이상 필요하지 않으면 불필요한 비용을 피하기 위해 반드시 삭제하세요.
+
+## 모든 Resource 삭제
+
+다음 command로 모든 stack을 삭제합니다.
+
+```bash
+cdk destroy
+```
+
+Cloud Shell session이 만료되었다면 source code를 다시 upload해야 하므로, 대신 CloudFormation console에서 stack을 삭제하세요.
+
+[https://console.aws.amazon.com/cloudformation/home#/stacks](https://console.aws.amazon.com/cloudformation/home#/stacks)
+
+`PASK` stack을 선택하고 삭제합니다.
+
+다음 resource는 자동으로 삭제되지 않으므로 수동으로 삭제해야 합니다. 이미 SageMaker를 사용 중이라면 해당 resource가 사용 중일 수 있으니 주의하세요.
+
+- Amazon CloudWatch log groups
+  - /aws/lambda/PASK-*
+  - /aws/sagemaker/Clusters/pask-cluster/*
+- S3 buckets
+  - pask-*

--- a/hyperpod/docs/ko/DEPLOYMENT.md
+++ b/hyperpod/docs/ko/DEPLOYMENT.md
@@ -1,0 +1,283 @@
+# Deployment
+
+이 sample은 CDK를 사용해 AWS resource를 provision합니다. CDK로 resource를 deploy하려면 충분한 permission을 가진 AWS credentials가 필요합니다.
+
+## 1. Prerequisites
+
+다음 environment에서 검증되었습니다.
+
+- Node.js v22.18.0
+- npm 10.9.3
+- aws-cli 2.32.21
+- Python 3.14 (Lambda)
+- Docker 25.0.8
+
+## 2. Deployment
+
+CDK deployment에 사용할 AWS credentials와 region을 지정하려면 다음 environment variables를 설정합니다. 이 sample은 us-east-1과 us-west-2에서 테스트되었습니다. 사용할 region을 `AWS_DEFAULT_REGION`에 설정하세요.
+
+```bash
+export AWS_ACCESS_KEY_ID=
+export AWS_SECRET_ACCESS_KEY=
+export AWS_DEFAULT_REGION=us-east-1
+```
+
+### 2.1. CDK Setup
+
+CDK가 설치되어 있지 않다면 [Getting started with the AWS CDK](https://docs.aws.amazon.com/cdk/v2/guide/getting-started.html)를 참고해 설치하세요.
+
+### 2.2. Clone the Sample
+
+GitHub에서 sample code를 clone합니다.
+
+```bash
+git clone https://github.com/aws-samples/sample-physical-ai-scaffolding-kit.git
+cd sample-physical-ai-scaffolding-kit/hyperpod
+```
+
+### 2.3. Install Node Modules
+
+이 CDK stack에 필요한 library를 설치합니다.
+
+```bash
+npm install
+```
+
+### 2.4. CDK Bootstrap
+
+CDK deployment에 필요한 environment를 준비합니다. 같은 region에서 한 번 이상 실행한 적이 있다면 이 단계는 건너뛸 수 있습니다.
+
+```bash
+cdk bootstrap
+```
+
+### 2.5. Configuration
+
+CDK가 deploy하는 architecture의 여러 설정을 구성할 수 있습니다. Configuration file은 [hyperpod/cdk.json](/hyperpod/cdk.json)에 있으며, 설정 가능한 section은 아래와 같습니다.
+초기 configuration에는 worker group 설정이 포함되어 있지 않습니다. Worker group은 일반적으로 GPU instance를 사용하므로, 먼저 worker group 없이 deploy하면 instance allocation이 불가능할 때 전체 deployment가 실패하는 것을 피할 수 있습니다. Worker group deployment는 이후 단계에서 다룹니다.
+
+변경하려면 `vim cdk.json`을 실행하고 command-line editor로 수정합니다.
+
+```json
+"config": {
+  "StackName": "PASK",  // Change this to modify the CloudFormation stack name
+  "Cluster": {
+    "Name": "pask-cluster",  // Amazon SageMaker HyperPod cluster name
+    "ControllerGroup": {
+      "Name": "controller-group",
+      "Count": 1,
+      "InstanceType": "ml.c5.large"
+    },
+    "LoginGroup": {
+      "Name": "login-group",
+      "Count": 1,
+      "InstanceType": "ml.c5.large"
+    },
+    "WorkerGroup": []
+  },
+  "ClusterVPC": {
+    "SubnetAZ": "",  // Specify a particular AZ in advance if needed
+    "UseFlowLog": false  // Set to true to enable VPC Flow Logs
+  },
+  "Lustre": {
+    "S3Prefix": "",  // Specify the S3 bucket path for the Lustre link target if needed
+    "FileSystemPath": "/s3link"  // The path on the node will be `/fsx/<value specified here>`
+  }
+}
+```
+
+#### 2.5.1. Cluster Availability Zone 지정
+
+기본적으로 g5, g6, g6e, g7e instance를 지원하는 AZ가 자동으로 선택됩니다.
+
+[AZ selection custom resource](/hyperpod/lib/lambda/custom-resources/subnet-selector/index.py)
+
+다른 특정 instance type을 사용해야 한다면 다음 command로 적절한 AZ를 찾고, cdk.json의 `ClusterVPC.SubnetAZ`에 설정하세요.
+
+```bash
+aws ec2 describe-instance-type-offerings --location-type availability-zone --filters Name=instance-type,Values=p4d.24xlarge
+```
+
+### 2.6. Deploy the Stack
+
+다음 command를 실행해 environment를 build합니다. Permission 확인 prompt가 표시되면 `y`를 입력해 진행합니다. 이 command는 모든 resource를 한 번에 생성하므로 완료까지 수십 분이 걸릴 수 있습니다.
+
+```sh
+cdk deploy
+```
+
+Deployment가 성공하면 다음과 유사한 output이 표시됩니다. AWS Management Console에서 CloudFormation을 열고 `PASK` stack을 선택한 뒤 `Outputs` tab에서도 확인할 수 있습니다.
+
+```bash
+Outputs:
+PASK.BucketDataBucketName = S3 bucket name for storing data
+PASK.ClusterAZNameParameterStore = Parameter Store name containing the AZ where the cluster is deployed
+PASK.ClusterClusterAvailabilityZone = AZ where the cluster is deployed
+PASK.HyperPodClusterExecutionRoleARN = Role ARN for the cluster nodes
+PASK.HyperPodClusterId = Cluster ID
+PASK.HyperPodClusterSecurityGroup = Security group used by the cluster
+PASK.HyperPodClusterSubnet = Subnet ID where the cluster is deployed
+PASK.HyperPodLifeCycleScriptBucketName = S3 bucket for lifecycle scripts
+PASK.HyperPodLoginGroupName = Login group name of the cluster
+PASK.Region = Region where resources are deployed
+```
+
+Cluster에서 이 정보를 가져오려면 다음 command를 사용합니다. 실제로 사용하는 region과 stack name으로 바꿔 실행하세요.
+
+```bash
+export AWS_DEFAULT_REGION=us-east-1
+aws cloudformation describe-stacks --stack-name PASK --query "Stacks[0].Outputs"
+```
+
+이 시점에서 기본 resource 준비가 완료됩니다.
+
+### 2.7. Initial Cluster Setup
+
+Deployment를 통해 HyperPod에 cluster가 provision되었습니다. 이 section에서는 cluster에 SSH로 접속하는 방법을 설명합니다.
+
+먼저 [SSH setup script](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod-run-jobs-slurm-access-nodes.html)를 사용해 local machine에서 SSH access를 설정합니다.
+
+```bash
+wget https://raw.githubusercontent.com/awslabs/awsome-distributed-training/refs/heads/main/1.architectures/5.sagemaker-hyperpod/easy-ssh.sh -O easy-ssh.sh
+chmod +x easy-ssh.sh
+```
+
+**Note:** `easy-ssh.sh`를 실행하기 전에 AWS credentials를 설정해야 합니다.
+
+진행 중 `~/.ssh/config`에 entry를 추가할지, SSH key를 생성할지 질문을 받습니다. `yes`로 답하면 이후 login이 더 간단해집니다.
+
+`easy-ssh.sh`는 `PASK.HyperPodLoginGroupName`과 `PASK.HyperPodClusterId` 값을 argument로 받습니다. Default settings에서는 command가 다음과 같습니다.
+
+```bash
+./easy-ssh.sh -c login-group pask-cluster
+```
+
+SSH connection이 성공하면 다음과 유사한 output이 표시됩니다.
+
+```bash
+Now you can run:
+
+$ ssh pask-cluster
+
+Starting session with SessionId: xxxxxxxx
+#
+```
+
+이것은 login node의 root SSH session이므로 `exit`를 입력해 disconnect합니다.
+
+종료한 뒤 script 실행 중 표시된 `ssh pask-cluster` command로 다시 접속합니다.
+
+**Note:** `easy-ssh.sh`가 `~/.ssh/config`에 추가한 SSH configuration은 [AWS Systems Manager Session Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager.html)를 사용하는 ProxyCommand로 SSH connection을 구성합니다. 따라서 **SSH를 사용할 때도 AWS credentials를 설정해야 합니다**.
+
+```bash
+Host pask-cluster
+    User ubuntu
+    ProxyCommand sh -c "aws ssm start-session --target sagemaker-cluster:xxxxxxx_controller-group-i-xxxxxxxx --document-name AWS-StartSSHSession --parameters 'portNumber=%p'"
+```
+
+Session Manager session은 inactivity가 20분(default) 지속되면 timeout됩니다. Timeout을 늘리려면 [AWS Systems Manager documentation](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-preferences-timeout.html)을 참고하세요.
+
+SSH connection이 성공하면 login node에 ubuntu user로 로그인됩니다.
+
+```bash
+
+...omitted...
+
+You're on the login
+Controller Node IP: 10.1.xxx.xxx
+Login Node IP: 10.1.xxx.xxx
+Instance Type: ml.c5.large
+ubuntu@ip-10-1-155-217:~$
+```
+
+ubuntu user가 S3-linked Lustre storage directory에 write할 수 있도록 permission을 설정합니다.
+
+```bash
+sudo chmod -R 777 /fsx/s3link
+```
+
+File을 write한 뒤 S3에 나타나는지 확인합니다.
+
+```bash
+touch /fsx/s3link/test.txt
+```
+
+[Management Console](https://console.aws.amazon.com/s3/buckets)을 열고 `pask-bucketdata`로 시작하는 bucket을 선택한 다음, 방금 만든 file이 존재하는지 확인합니다.
+
+확인이 끝나면 `exit`로 login node에서 나옵니다.
+
+남은 단계는 local terminal에서 수행합니다.
+
+### 2.8. Adding Worker Groups
+
+Worker group을 추가하려면 cdk.json을 수정하고 redeploy해야 합니다.
+아래 절차에 따라 worker group을 추가합니다.
+
+#### Instance Limit Increase 요청 및 Instance 예약
+
+사용하려는 instance에 대해 quota increase를 요청해야 할 수 있습니다. 현재 limit이 필요한 instance 수와 일치하는지 확인하고, 필요하다면 increase를 요청하세요. **Instance type과 수량에 따라 approval에 시간이 걸릴 수 있습니다.**
+
+Limit increase를 요청하려면 다음 절차를 따릅니다. **올바른 AWS account에 로그인되어 있는지 반드시 확인하세요.**
+
+1. <https://console.aws.amazon.com/servicequotas/> 로 이동합니다.
+1. 왼쪽 menu에서 `AWS services`를 선택합니다.
+1. `Amazon SageMaker`를 검색해 선택합니다.
+1. Search field에 `for cluster usage`를 입력하고 결과에서 사용할 instance type을 선택합니다.
+1. `Request increase at account level` button을 클릭합니다.
+1. `Increase quota value`에 원하는 값을 입력하고 `Request`를 클릭합니다.
+
+**Note:** 이것은 limit increase request이며, instance availability를 보장하지 않습니다.
+
+Worker group의 instance를 allocate할 수 없으면 deployment가 실패합니다. 특히 GPU instance type의 경우 [Amazon SageMaker HyperPod flexible training plans](https://aws.amazon.com/blogs/aws/meet-your-training-timelines-and-budgets-with-new-amazon-sagemaker-hyperpod-flexible-training-plans/)를 사용해 instance를 reserve해야 합니다. 자세한 절차는 [Amazon SageMaker HyperPod flexible training plans](https://aws.amazon.com/blogs/aws/meet-your-training-timelines-and-budgets-with-new-amazon-sagemaker-hyperpod-flexible-training-plans/)를 참고하세요.
+
+**Note:** Training plan은 구매 후 취소할 수 없습니다. Target과 Instance Type을 다시 확인해 실수를 피하세요.
+
+**Amazon SageMaker HyperPod flexible training plans**를 사용하는 경우 quota page에서 `reserved capacity across training plans per Region`을 검색하고, 해당 instance에 대한 limit increase를 요청합니다.
+
+### 2.9. Deploy CDK to Create Worker Groups
+
+아래처럼 worker group configuration을 `cdk.json`에 추가합니다. 사용할 instance type을 지정하세요. 여러 worker group을 추가하려면 여러 entry를 포함합니다.
+
+```json
+"Cluster": {
+  "Name": "pask-cluster",
+  "ControllerGroup": {
+    "Name": "controller-group",
+    "Count": 1,
+    "InstanceType": "ml.c5.large"
+  },
+  "LoginGroup": {
+    "Name": "login-group",
+    "Count": 1,
+    "InstanceType": "ml.c5.large"
+  },
+  "WorkerGroup": [
+    {
+      "Name": "worker-group-1",
+      "Count": 1,
+      "InstanceType": "ml.g6e.2xlarge"
+    }
+  ]
+},
+```
+
+cdk.json을 수정한 뒤 다음 command로 redeploy합니다.
+
+```bash
+cdk deploy
+```
+
+Deployment가 성공하면 worker node를 사용할 수 있습니다.
+
+다음과 유사한 error로 deployment가 실패하면 instance를 allocate할 수 없다는 뜻입니다. 잠시 후 다시 시도하거나, deploy 전에 instance를 reserve하세요.
+
+```bash
+❌  PASK failed: ToolkitError: The stack named PASK failed to deploy: UPDATE_ROLLBACK_COMPLETE: Resource handler returned message: "Resource of type 'AWS::SageMaker::Cluster' with identifier 'Operation [UPDATE] on [arn:aws:sagemaker:us-east-1:0000000000:cluster/xxxxxxx] failed with status [InService] and error [We currently do not have sufficient capacity to launch new ml.g6e.2xlarge instances. Please try again.]' did not stabilize." (RequestToken: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx, HandlerErrorCode: NotStabilized)
+```
+
+---
+
+기본 Amazon SageMaker HyperPod environment 준비가 완료되었습니다.
+Management Console에서 HyperPod cluster를 보려면 [https://console.aws.amazon.com/sagemaker/home#/cluster-management](https://console.aws.amazon.com/sagemaker/home#/cluster-management)로 이동합니다. Cluster가 표시되지 않으면 올바른 region이 선택되어 있는지 확인하세요.
+
+HyperPod의 node들은 shared Lustre storage를 `/fsx`에 mount합니다. Default user인 ubuntu의 home directory는 Lustre의 `/fsx/ubuntu`로 설정됩니다. Lustre path `/fsx/s3link`는 `PASK.BucketDataBucketName`에 표시된 S3 bucket과 [linked data repository로 연결](https://docs.aws.amazon.com/fsx/latest/LustreGuide/create-dra-linked-data-repo.html)되어 있습니다. Large dataset을 사용할 때는 이 S3 bucket에 data를 upload하고 cluster에서 접근하면 됩니다. 각 node는 Lustre를 통해 S3 data에 접근할 수 있어 data 사용이 간단해집니다.

--- a/samples/gr00t/README.ja.md
+++ b/samples/gr00t/README.ja.md
@@ -1,4 +1,4 @@
-日本語 | [English](./README.md)
+日本語 | [English](./README.md) | [한국어](./README.ko.md)
 
 # NVIDIA Isaac GR00T on Amazon SageMaker HyperPod
 

--- a/samples/gr00t/README.ko.md
+++ b/samples/gr00t/README.ko.md
@@ -1,0 +1,9 @@
+[日本語](./README.ja.md) | [English](./README.md) | 한국어
+
+# NVIDIA Isaac GR00T on Amazon SageMaker HyperPod
+
+이 디렉터리는 Amazon SageMaker HyperPod에서 NVIDIA Isaac GR00T model training을 실행하기 위한 sample scripts를 제공합니다.
+
+## Documents
+
+1. [Training](/samples/gr00t/docs/ko/training.md): AWS SageMaker HyperPod에서 Slurm + Enroot로 Docker container fine-tuning을 실행하는 가이드

--- a/samples/gr00t/README.md
+++ b/samples/gr00t/README.md
@@ -1,4 +1,4 @@
-[日本語](./README.ja.md) | English
+[日本語](./README.ja.md) | English | [한국어](./README.ko.md)
 
 # NVIDIA Isaac GR00T on Amazon SageMaker HyperPod
 

--- a/samples/gr00t/docs/ko/training.md
+++ b/samples/gr00t/docs/ko/training.md
@@ -1,0 +1,325 @@
+# NVIDIA Isaac GR00T Training Guide with HyperPod + Slurm + Enroot
+
+AWS SageMaker HyperPod에서 Slurm + Enroot를 사용해 Docker container 안에서 GR00T fine-tuning을 실행하는 가이드입니다.
+
+## Architecture
+
+```mermaid
+flowchart TB
+    login[Login Node<br/>Docker Build & Push]
+    ecr[Container Registry<br/>Amazon ECR]
+    fsx[FSx for Lustre<br/>/fsx shared]
+    compute[Compute Node<br/>sbatch<br/>Enroot]
+
+    login -->|Docker Build & Push| ecr
+    ecr -->|Enroot Import| login
+    fsx -.->|shared storage| login
+    login -->|sbatch| compute
+
+    style ecr fill:#fff4e1
+    style login fill:#f0f0f0
+    style fsx fill:#f0f0f0
+    style compute fill:#d4f4dd
+```
+
+---
+
+## Prerequisites
+
+1. **HyperPod Cluster**: 이 project에 포함된 CDK로 AWS에 구축한 HyperPod cluster
+   - Console 등으로 직접 생성한 HyperPod cluster도 training에 사용할 수 있습니다.
+2. **Git LFS**: Isaac GR00T repository는 sample data와 large files에 Git LFS를 사용합니다.
+
+---
+
+## Steps
+
+### Phase 1: HyperPod Login Node에서 준비
+
+#### 1.1 HyperPod에 SSH 접속
+
+```bash
+ssh pask-cluster
+```
+
+#### 1.2 PASK Repository Clone
+
+```bash
+cd
+git clone https://github.com/aws-samples/sample-physical-ai-scaffolding-kit.git
+```
+
+#### 1.2 Git LFS 설치
+
+[Isaac GR00T](https://github.com/NVIDIA/Isaac-GR00T) repository는 sample data 같은 large files에 Git LFS를 사용합니다. [Installation instructions](https://github.com/git-lfs/git-lfs/wiki/Installation)를 따라 설치하세요.
+
+`Which services should be restarted?` prompt가 표시되면 Tab key로 `<Ok>`를 선택하고 Enter를 눌러 계속합니다.
+
+```bash
+curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash
+sudo apt-get update
+sudo apt-get install git-lfs
+git lfs install
+```
+
+#### 1.3 Log Output Directory 생성
+
+```bash
+mkdir -p /fsx/ubuntu/joblog
+```
+
+#### 1.4 Isaac GR00T Repository Clone
+
+[**Installation Guide**](https://github.com/NVIDIA/Isaac-GR00T/tree/main?tab=readme-ov-file#installation-guide)에 따라 repository를 clone합니다.
+
+```bash
+cd
+git clone --recurse-submodules https://github.com/NVIDIA/Isaac-GR00T
+export GR00T_HOME="$HOME/Isaac-GR00T"
+```
+
+---
+
+### Phase 2: Docker Image Build 및 ECR Push
+
+#### 2.1 Docker Image Build 및 ECR Push
+
+Login node에서 Docker image를 build하고 ECR에 push합니다.
+
+```bash
+cd ~/sample-physical-ai-scaffolding-kit/samples/gr00t/training
+sbatch slurm_build_docker.sh
+```
+
+**Environment Information을 가져오는 방식 (HyperPod Cluster)**:
+
+Script는 다음 priority로 environment information을 가져옵니다. HyperPod 안에서 command-line argument나 environment variable 설정 없이 실행하면 EC2 instance metadata에서 정보를 가져옵니다.
+
+1. **Environment variables** (`AWS_REGION`, `AWS_ACCOUNT_ID`)
+2. **Auto-detection**
+   - **Region**: EC2 instance metadata (IMDSv2)
+   - **Account ID**: AWS STS (`aws sts get-caller-identity`)
+3. **Fallback**: Region default는 `us-east-1`
+
+**Available Environment Variables**:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GR00T_HOME` | (required) | Isaac-GR00T repository path |
+| `ECR_REPOSITORY` | `gr00t-train` | ECR repository name |
+| `IMAGE_TAG` | `latest` | Docker image tag |
+| `AWS_REGION` | Auto-detected | AWS region |
+| `AWS_ACCOUNT_ID` | Auto-detected | AWS account ID |
+
+```bash
+# Example: repository name과 image tag 변경
+GR00T_HOME=$HOME/Isaac-GR00T ECR_REPOSITORY=my-gr00t IMAGE_TAG=v1.0.0 \
+    sbatch slurm_build_docker.sh
+```
+
+**What It Does**:
+
+- ECR repository `gr00t-train`을 생성합니다. 이미 있으면 건너뜁니다.
+- Docker image를 build합니다. Isaac GR00T의 `docker/Dockerfile`을 사용합니다.
+- ECR에 push합니다.
+
+**Checking Progress**:
+
+```bash
+# job status 확인
+squeue
+
+# job ID를 찾아 variable로 설정
+JOBID=<JOB_ID>
+
+# 상세 status 확인
+sacct -j $JOBID
+
+# log를 real time으로 monitor
+tail -f /fsx/ubuntu/joblog/docker_build_$JOBID.out
+
+# error log 확인
+tail -f /fsx/ubuntu/joblog/docker_build_$JOBID.err
+```
+
+**Example Output**:
+
+```bash
+==================================================
+Docker build and push completed successfully
+End Time: Sat Mar 21 01:54:06 UTC 2026
+==================================================
+```
+
+---
+
+### Phase 3: Enroot Container Import
+
+#### 3.1 Docker Image를 SquashFS Format으로 변환
+
+Docker로 build한 image를 Enroot로 변환합니다. Local Docker cache가 있으면 사용하고, 없으면 ECR에서 image를 pull합니다.
+
+```bash
+cd ~/sample-physical-ai-scaffolding-kit/samples/gr00t/training
+bash ./hyperpod_import_container.sh
+```
+
+완료 후 다음 command로 확인할 수 있습니다.
+
+```bash
+export ENROOT_DATA_PATH=/fsx/enroot/data
+enroot list
+```
+
+Argument 지정 예시는 다음과 같습니다.
+
+```bash
+# image tag 지정
+bash ./hyperpod_import_container.sh v1.0.0
+
+# region 지정
+bash ./hyperpod_import_container.sh latest us-west-2
+
+# 모든 parameter 지정
+bash ./hyperpod_import_container.sh latest us-west-2 123456789012
+```
+
+**Environment Information을 가져오는 방식 (HyperPod Cluster)**:
+
+Script는 다음 priority로 environment information을 가져옵니다.
+
+1. **Command-line arguments** (highest priority)
+
+   ```bash
+   ./hyperpod_import_container.sh [IMAGE_TAG] [AWS_REGION] [AWS_ACCOUNT_ID]
+   ```
+
+2. **Environment variables**
+
+   ```bash
+   export AWS_REGION=us-west-2
+   export AWS_ACCOUNT_ID=123456789012
+   ./hyperpod_import_container.sh
+   ```
+
+3. **Auto-detection**
+   - **Region**: EC2 instance metadata (IMDSv2)
+   - **Account ID**: AWS STS (`aws sts get-caller-identity`)
+
+4. **Fallback**: Region default는 `us-east-1`
+
+**Available Environment Variables**:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `IMAGE_TAG` | `latest` | Import할 Docker image tag |
+| `AWS_REGION` | Auto-detected | AWS region |
+| `AWS_ACCOUNT_ID` | Auto-detected | AWS account ID |
+| `ENROOT_CACHE_PATH` | `/fsx/enroot` | Enroot cache directory |
+| `ENROOT_DATA_PATH` | `/fsx/enroot/data` | Enroot data directory (`.sqsh` output location) |
+
+**What It Does**:
+
+- Local Docker cache를 확인합니다. 없으면 ECR에서 pull합니다.
+- SquashFS format (`.sqsh`)으로 변환합니다.
+- `ENROOT_DATA_PATH`에 저장합니다.
+
+---
+
+### Phase 4: Slurm Job 실행
+
+#### 4.1 Fine-Tuning 실행
+
+S3에 upload한 file을 training data로 사용하는 경우 write operation이 발생하므로, 아래처럼 permission을 먼저 변경한 뒤 training command를 실행합니다.
+Sample data가 Lustre의 `/fsx/ubuntu/` 아래에 있으면 permission 변경이 필요 없습니다.
+
+```bash
+DATASET_PATH=/fsx/s3link/my_dataset
+sudo chmod -R a+w "${DATASET_PATH}"
+```
+
+Training job parameter는 environment variables로 customize할 수 있습니다.
+
+```bash
+# Example: GPU 수, step 수, dataset 변경
+NUM_GPUS=2 MAX_STEPS=5000 DATASET_PATH=/fsx/ubuntu/my_dataset \
+    sbatch slurm_finetune_container.sh
+```
+
+**Available Environment Variables**:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NUM_GPUS` | `1` | 사용할 GPU 수 |
+| `MAX_STEPS` | `2000` | Maximum training steps |
+| `SAVE_STEPS` | `2000` | Checkpoint save interval |
+| `GLOBAL_BATCH_SIZE` | `32` | Global batch size |
+| `OUTPUT_DIR` | `/fsx/s3link/so100` | Checkpoint output directory |
+| `DATASET_PATH` | `./demo_data/cube_to_bowl_5` | Training dataset path |
+| `BASE_MODEL` | `nvidia/GR00T-N1.6-3B` | Base model |
+
+Minimal command입니다. 모든 default value를 사용합니다.
+
+```bash
+cd ~/sample-physical-ai-scaffolding-kit/samples/gr00t/training
+
+export GR00T_HOME="$HOME/Isaac-GR00T"
+sbatch slurm_finetune_container.sh
+```
+
+**Checking Progress**:
+
+```bash
+# job status 확인
+squeue
+
+# job ID를 찾아 variable로 설정
+JOBID=<JOB_ID>
+
+# 상세 status 확인
+sacct -j $JOBID
+
+# log를 real time으로 monitor
+tail -f /fsx/ubuntu/joblog/finetune_$JOBID.out
+
+# error log 확인
+tail -f /fsx/ubuntu/joblog/finetune_$JOBID.err
+```
+
+---
+
+## Slurm Job Management Commands
+
+### Checking Jobs
+
+```bash
+# 본인 job 목록
+squeue -u ubuntu
+
+# 상세 정보
+squeue -u ubuntu -o "%.18i %.9P %.30j %.8u %.2t %.10M %.6D %R"
+
+# 모든 job (entire cluster)
+squeue
+```
+
+### Canceling Jobs
+
+```bash
+# 특정 job cancel
+scancel <JOB_ID>
+
+# 본인 job 전체 cancel
+scancel -u ubuntu
+```
+
+---
+
+## Reference Resources
+
+### Documentation
+
+- [NVIDIA Isaac GR00T](https://github.com/NVIDIA/Isaac-GR00T) - Official repository
+- [AWS HyperPod Documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod.html)
+- [Enroot Documentation](https://github.com/NVIDIA/enroot)
+- [Slurm Documentation](https://slurm.schedmd.com/documentation.html)

--- a/samples/openpi-sample/README.ja.md
+++ b/samples/openpi-sample/README.ja.md
@@ -1,4 +1,4 @@
-日本語 | [English](./README.md)
+日本語 | [English](./README.md) | [한국어](./README.ko.md)
 
 # OpenPI on Amazon SageMaker HyperPod
 

--- a/samples/openpi-sample/README.ko.md
+++ b/samples/openpi-sample/README.ko.md
@@ -1,0 +1,9 @@
+[日本語](./README.ja.md) | [English](./README.md) | 한국어
+
+# OpenPI on Amazon SageMaker HyperPod
+
+이 디렉터리는 Amazon SageMaker HyperPod에서 OpenPI (Physical Intelligence) model training과 inference를 실행하기 위한 sample scripts를 제공합니다.
+
+## Documentation
+
+1. [LoRA Training](docs/ko/pi0_LoRA_training.md): AWS SageMaker HyperPod에서 Slurm + Enroot로 Docker container LoRA fine-tuning을 실행하는 가이드

--- a/samples/openpi-sample/README.md
+++ b/samples/openpi-sample/README.md
@@ -1,4 +1,4 @@
-[日本語](./README.ja.md) | English
+[日本語](./README.ja.md) | English | [한국어](./README.ko.md)
 
 # OpenPI on Amazon SageMaker HyperPod
 

--- a/samples/openpi-sample/docs/ko/pi0_LoRA_training.md
+++ b/samples/openpi-sample/docs/ko/pi0_LoRA_training.md
@@ -1,0 +1,357 @@
+# OpenPI LoRA Training Guide with HyperPod + Slurm + Enroot
+
+AWS SageMaker HyperPod에서 Slurm + Enroot를 사용해 Docker container 안에서 LoRA fine-tuning을 실행하는 가이드입니다.
+
+## Architecture
+
+```mermaid
+flowchart TB
+    local[Local / EC2<br/>Docker Build]
+    S3[S3 Bucket<br/>Training Data, Code]
+    ecr[Container Registry<br/>Amazon ECR]
+    login[Login Node<br/>Slurm Master]
+    fsx[FSx for Lustre<br/>/fsx shared]
+    compute[Compute Node<br/>srun --container-image<br/>Pyxis + Enroot]
+
+    local -->|Docker Build & Push| ecr
+    local -->|Data Transfer| S3
+    ecr -->|Enroot Import| login
+    S3 -.->|shared storage| fsx
+    fsx -.->|shared storage| login
+    login -->|sbatch| compute
+
+    style local fill:#e1f5ff
+    style ecr fill:#fff4e1
+    style login fill:#f0f0f0
+    style fsx fill:#f0f0f0
+    style compute fill:#d4f4dd
+```
+
+***
+
+## Prerequisites
+
+1. **HyperPod Cluster**: 이 project에 포함된 CDK로 AWS에 구축한 HyperPod cluster가 필요합니다.
+   아래 단계는 CDK로 deploy한 HyperPod cluster를 가정하지만, console에서 수동으로 생성한 cluster도 training에 사용할 수 있습니다.
+2. **Development Environment**: 다음 setup이 필요합니다.
+   1. AWS credentials configuration: ECR access에 필요합니다.
+   2. Docker: pi0 training image build에 필요합니다.
+3. **Hugging Face Token**: Sample training dataset download에 필요합니다 (`HF_TOKEN`).
+   1. [Hugging Face](https://huggingface.co/settings/tokens)에 sign up하고 token을 미리 생성해야 합니다. 직접 준비한 training data를 사용할 경우 필요하지 않습니다.
+
+***
+
+## Execution Steps
+
+### Local에서 Image Build 및 ECR Push
+
+#### Docker Image Build 및 ECR Push
+
+```bash
+cd samples/openpi-sample/
+
+# Clone openpi
+git clone https://github.com/Physical-Intelligence/openpi.git
+
+cd lora_training/
+
+# ECR로 build & push (AWS CLI default region 사용)
+./build_and_push_ecr.sh
+
+# region과 account ID를 모두 지정
+./build_and_push_ecr.sh us-west-2 123456789012
+
+# 특정 tag 지정
+IMAGE_TAG=v1.0.0 ./build_and_push_ecr.sh
+```
+
+**Environment Information을 가져오는 방식 (Local PC)**:
+
+Script는 다음 priority로 environment information을 가져옵니다.
+
+1. **Command-line arguments** (highest priority)
+2. **Environment variables** (`AWS_REGION`, `AWS_ACCOUNT_ID`)
+3. **AWS CLI configuration**
+   * Region: `aws configure get region`
+   * Account ID: `aws sts get-caller-identity --query Account --output text`
+
+**What the script does**:
+* ECR repository `openpi-lora-train`을 생성합니다. 이미 있으면 건너뜁니다.
+* Docker image를 build합니다. `train_lora.Dockerfile`을 사용합니다.
+* ECR에 push합니다.
+
+**Example output**:
+
+```
+✅ Docker image successfully pushed to ECR
+Image URI: 123456789012.dkr.ecr.us-west-2.amazonaws.com/openpi-lora-train:latest
+```
+
+***
+
+### HyperPod Login Node 준비
+
+#### HyperPod SSH Connection
+
+[/hyperpod/docs/ko/DEPLOYMENT.md](/hyperpod/docs/ko/DEPLOYMENT.md)의 SSH connection 안내에 따라 접속합니다.
+
+```
+ssh pask-cluster
+```
+
+#### Project Setup
+
+```bash
+# PASK repository clone
+cd
+git clone https://github.com/aws-samples/sample-physical-ai-scaffolding-kit.git
+
+# setup 실행. Parameter는 아래 설명 참고
+cd samples/openpi-sample/lora_training
+./setup.sh --hf-token "hf_xxxxx"
+
+# environment variables 적용
+source ~/.bashrc
+```
+
+**Parameters**
+* hf-token (optional): "hf\_"로 시작하는 Hugging Face token을 지정합니다.
+  * [Hugging Face](https://huggingface.co/settings/tokens)에 sign up하고 token을 미리 생성해야 합니다.
+
+**What the script does**
+
+1. OpenPI repository를 clone합니다.
+   - /fsx/ubuntu/samples/openpi-sample/openpi/ 가 없을 때 실행됩니다.
+   - GitHub에서 git clone <https://github.com/Physical-Intelligence/openpi.git> 를 실행합니다.
+2. Directory structure를 생성합니다.
+   - /fsx/ubuntu/samples/openpi-sample/logs/
+   - /fsx/ubuntu/samples/openpi-sample/.cache/
+   - /fsx/ubuntu/samples/openpi-sample/openpi/assets/physical-intelligence/libero/
+3. \~/.bashrc에 environment variables를 설정합니다.
+   - 기존 OpenPI/Enroot 설정이 있으면 제거하고 backup을 생성합니다.
+   - 다음 environment variables를 추가합니다. 이 environment variables는 모든 Slurm job script에서 사용됩니다.
+     * export OPENPI\_BASE\_DIR=/fsx/ubuntu/samples/openpi-sample
+     * export OPENPI\_PROJECT\_ROOT=\${OPENPI\_BASE\_DIR}/openpi
+     * export OPENPI\_DATA\_HOME=\${OPENPI\_BASE\_DIR}/.cache
+     * export OPENPI\_LOG\_DIR=\${OPENPI\_BASE\_DIR}/logs
+     * export HF\_TOKEN=<value specified as argument or empty>
+     * export ENROOT\_CACHE\_PATH=/fsx/enroot
+     * export ENROOT\_DATA\_PATH=/fsx/enroot/data
+
+**About Weights & Biases (wandb)**:
+* Default scripts는 wandb를 disable합니다 (`--no-wandb-enabled`).
+* wandb로 training을 track하려면:
+  1. [wandb.ai](https://wandb.ai)에서 account를 생성합니다.
+  2. API key를 가져와 `~/.bashrc`에 추가합니다: `export WANDB_API_KEY=your_key_here`
+  3. Script에서 `--no-wandb-enabled`를 제거하거나 `--wandb-enabled`로 변경합니다.
+
+---
+
+#### Enroot로 Docker Image Import
+
+```bash
+# ECR image를 Enroot format으로 변환
+cd samples/openpi-sample/lora_training
+
+# EC2 metadata에서 auto-detect
+./hyperpod_import_container.sh
+
+# image tag 지정
+./hyperpod_import_container.sh v1.0.0
+
+# region 지정
+./hyperpod_import_container.sh latest us-west-2
+```
+
+**Environment Information을 가져오는 방식 (HyperPod Cluster)**:
+
+Script는 다음 priority로 environment information을 가져옵니다. HyperPod 안에서 command-line argument나 environment variable을 지정하지 않으면 EC2 instance metadata에서 정보를 가져옵니다.
+
+1. **Command-line arguments** (highest priority)
+
+   ```bash
+   ./hyperpod_import_container.sh [IMAGE_TAG] [AWS_REGION] [AWS_ACCOUNT_ID]
+   ```
+
+2. **Environment variables**
+
+   ```bash
+   export AWS_REGION=us-west-2
+   export AWS_ACCOUNT_ID=123456789012
+   ./hyperpod_import_container.sh
+   ```
+
+3. **Auto-detection**
+
+   * **Region**: EC2 instance metadata (IMDSv2)
+
+     ```bash
+     TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" \
+       -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" -s)
+     curl -H "X-aws-ec2-metadata-token: $TOKEN" -s \
+       http://169.254.169.254/latest/meta-data/placement/region
+     ```
+
+   * **Account ID**: AWS STS
+
+     ```bash
+     aws sts get-caller-identity --query Account --output text
+     ```
+
+4. **Fallback**: Region default는 `us-east-1`
+
+**What the script does**:
+* ECR에서 Docker image를 pull합니다.
+* SquashFS format (`.sqsh`)으로 변환합니다.
+* `/fsx/enroot/data/`에 저장합니다.
+
+**Example output**:
+
+```
+✅ Container ready for Slurm execution
+Container Name: openpi-lora-train+latest.sqsh
+```
+
+**Verification**:
+
+```bash
+# import된 container 확인
+enroot list
+
+# Example output:
+# openpi-lora-train+latest.sqsh
+```
+
+***
+
+### Slurm Jobs 실행
+
+#### Normalization Statistics 계산 (처음 한 번만)
+
+```bash
+cd samples/openpi-sample/lora_training
+
+# Slurm job으로 submit
+sbatch ./slurm_compute_norm_stats.sh pi0_libero_low_mem_finetune
+
+# job ID가 반환됩니다. 예: Submitted batch job 1234
+```
+
+**Checking progress**:
+
+```bash
+# job status 확인
+squeue -u ubuntu
+
+# log를 real time으로 monitor
+tail -f ${OPENPI_LOG_DIR}/slurm_<JOB_ID>.out
+
+# error log 확인
+tail -f ${OPENPI_LOG_DIR}/slurm_<JOB_ID>.err
+```
+
+##### Execution Errors
+
+**Hugging Face Quota Error**:
+Sample training data를 사용할 때 Hugging Face에서 download 중 다음과 같은 quota error가 발생할 수 있습니다.
+이 경우 최소 5분을 기다린 뒤 `./slurm_compute_norm_stats.sh`를 다시 실행하세요.
+Download는 중단된 지점부터 resume되므로 두 번째 시도에서는 quota error 없이 완료됩니다.
+
+```
+huggingface_hub.errors.HfHubHTTPError: 429 Client Error: Too Many Requests for url: https://huggingface.co/api/datasets/physical-intelligence/
+We had to rate limit you, you hit the quota of 1000 api requests per 5 minutes period. Upgrade to a PRO user or Team/Enterprise organization account (https://hf.co/pricing) to get higher limits. See https://huggingface.co/docs/hub/rate-limits
+```
+
+***
+
+#### LoRA Fine-Tuning 실행 (GPU Job)
+
+```bash
+cd samples/openpi-sample/lora_training
+
+# LoRA training submit
+sbatch ./slurm_train_lora.sh pi0_libero_low_mem_finetune my_lora_run
+
+# custom experiment name으로 실행
+sbatch ./slurm_train_lora.sh pi0_libero_low_mem_finetune experiment_$(date +%Y%m%d)
+```
+
+**Checking progress**:
+
+```bash
+# job status 확인
+squeue -u ubuntu
+
+# GPU usage 확인 (compute node에서)
+srun --jobid=<JOB_ID> nvidia-smi
+
+# log를 real time으로 monitor
+tail -f ${OPENPI_LOG_DIR}/train_<JOB_ID>.out
+
+# error log 확인
+tail -f ${OPENPI_LOG_DIR}/train_<JOB_ID>.err
+```
+
+**Typical logs during training**:
+
+```
+[1000/30000] loss=0.234 lr=1e-4 step_time=1.2s
+[2000/30000] loss=0.189 lr=9e-5 step_time=1.1s
+Saving checkpoint to /fsx/ubuntu/openpi_test/openpi/checkpoints/pi0_libero_low_mem_finetune/my_lora_run/2000
+```
+
+**Verifying completion**:
+
+```bash
+# job completion status 확인
+sacct -j <JOB_ID> --format=JobID,State,ExitCode
+
+# checkpoints 확인
+ls -lh ${OPENPI_PROJECT_ROOT}/checkpoints/pi0_libero_low_mem_finetune/my_lora_run/
+
+# Example output:
+# drwxr-xr-x  1000/
+# drwxr-xr-x  2000/
+# drwxr-xr-x  5000/
+# drwxr-xr-x  30000/  <- Final checkpoint
+```
+
+***
+
+## Slurm Job Management Commands
+
+### Checking Jobs
+
+```bash
+# 본인 job 목록
+squeue -u ubuntu
+
+# 상세 정보
+squeue -u ubuntu -o "%.18i %.9P %.30j %.8u %.2t %.10M %.6D %R"
+
+# 모든 job (entire cluster)
+squeue
+```
+
+### Canceling Jobs
+
+```bash
+# 특정 job cancel
+scancel <JOB_ID>
+
+# 본인 job 전체 cancel
+scancel -u ubuntu
+
+# name으로 job cancel
+scancel --name=openpi_lora_train
+```
+
+***
+
+## Reference Resources
+
+### Documentation
+
+* [AWS HyperPod Documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod.html)
+* [Enroot Documentation](https://github.com/NVIDIA/enroot)
+* [Slurm Documentation](https://slurm.schedmd.com/documentation.html)


### PR DESCRIPTION
## Summary
- Adds Korean README files for the repository root, HyperPod, GR00T, and OpenPI.
- Adds Korean guide docs under `hyperpod/docs/ko`, `samples/gr00t/docs/ko`, and `samples/openpi-sample/docs/ko`.
- Updates English and Japanese README language switchers to include Korean links in `ja / en / ko` order.
