### PR TITLE
physai: Work around HyperPod Slurm 25.11 topology config crash

### DIFF
--- a/physai/infra/lifecycle/_lib.sh
+++ b/physai/infra/lifecycle/_lib.sh
@@ -80,5 +80,75 @@ slurm_reconfigure_with_retry() {
     return 1
 }
 
+# sanitize_slurm_topology: work around a HyperPod Slurm 25.11 topology config
+# that crashes slurmctld on the controller.
+#
+# Observed on HyperPod clusters on the Slurm 25.11 AMI: $SLURM_DIR/etc contains
+# an empty topology.yaml ("[]") and empty topology.conf, and the GPU
+# PartitionName carries a `Topology=tree` tag. With that config slurmctld
+# crash-loops on SIGSEGV and the controller never stays up (the visible
+# "No Assoc usage file" fatal is a downstream effect of that crash). We do not
+# know what makes HyperPod generate this config; a 24.11 cluster on the same
+# hardware had none of these lines and was healthy.
+#
+# Removing the empty topology files and stripping the Topology= token (i.e.
+# restoring the topology-free shape) is verified to let slurmctld start cleanly.
+# That is what this does.
+#
+# Idempotent. Returns 0 if it changed something (caller may then reconfigure),
+# 1 if nothing needed changing or real topology is present.
+sanitize_slurm_topology() {
+    local etc conf yaml tconf changed f yaml_stripped
+    etc="${SLURM_DIR:-/opt/slurm}/etc"
+    conf="$etc/slurm.conf"
+    yaml="$etc/topology.yaml"
+    tconf="$etc/topology.conf"
+    changed=false
+
+    if [[ ! -f "$conf" ]]; then
+        echo "sanitize_slurm_topology: $conf not found, skipping"
+        return 1
+    fi
+
+    # Safety guard: only act on HyperPod's EMPTY/placeholder topology artifacts.
+    # If real topology is defined (a topology.conf with SwitchName=/BlockName=
+    # entries, or a non-empty topology.yaml), this cluster legitimately uses
+    # topology-aware scheduling (e.g. p5) — leave everything untouched so the
+    # workaround can never disable a real feature.
+    if [[ -f "$tconf" ]] && grep -qiE '^[[:space:]]*(SwitchName|BlockName)=' "$tconf"; then
+        echo "sanitize_slurm_topology: $tconf defines real switches/blocks — not modifying"
+        return 1
+    fi
+    if [[ -f "$yaml" ]]; then
+        yaml_stripped=$(tr -d '[:space:]' < "$yaml")
+        if [[ -n "$yaml_stripped" && "$yaml_stripped" != "[]" ]]; then
+            echo "sanitize_slurm_topology: $yaml is non-empty — not modifying"
+            return 1
+        fi
+    fi
+
+    # Remove the empty topology files.
+    for f in "$yaml" "$tconf"; do
+        if [[ -e "$f" ]]; then
+            echo "sanitize_slurm_topology: removing empty $f"
+            rm -f "$f"
+            changed=true
+        fi
+    done
+
+    # Strip the orphaned `Topology=<x>` token from PartitionName lines.
+    if grep -Eq '^PartitionName=.*[[:space:]]Topology=' "$conf"; then
+        echo "sanitize_slurm_topology: stripping Topology= from PartitionName lines"
+        sed -i -E '/^PartitionName=/ s/[[:space:]]+Topology=[^[:space:]]+//g' "$conf"
+        changed=true
+    fi
+
+    if $changed; then
+        echo "sanitize_slurm_topology: applied HyperPod 25.11 topology workaround"
+        return 0
+    fi
+    return 1
+}
+
 _detect_node_type
 export NODE_TYPE

--- a/physai/infra/lifecycle/install_topology_watcher.sh
+++ b/physai/infra/lifecycle/install_topology_watcher.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# install_topology_watcher.sh — Keep the HyperPod Slurm 25.11 topology config
+# from re-breaking the controller after the cluster agent regenerates
+# slurm.conf.
+#
+# Runs on the CONTROLLER node only.
+#
+# The SageMaker cluster agent owns /opt/slurm/etc/slurm.conf and regenerates it
+# (observed: it reverts our edits, restoring the empty topology.yaml/topology.conf
+# and the `Topology=tree` PartitionName tag). start_slurm.sh sanitizes it before
+# slurmctld's first start (initial provision); this script covers every later
+# regeneration by re-applying sanitize_slurm_topology whenever slurm.conf changes.
+#
+# Installs two systemd units (same pattern as register_slurm_features.sh):
+#
+#   sanitize-slurm-topology.service (oneshot)
+#     - Re-runs sanitize_slurm_topology; if it changed anything, runs
+#       `scontrol reconfigure`. Sanitize BEFORE reconfigure so the running
+#       controller only ever reloads the cleaned config, never the raw
+#       regenerated one (which we know it crashes on).
+#
+#   sanitize-slurm-topology.path
+#     - Watches /opt/slurm/etc/slurm.conf and triggers the .service on every
+#       modification — i.e. every time the cluster agent rewrites it.
+#
+# Usage: install_topology_watcher.sh
+set -exo pipefail
+# shellcheck source=_lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+require_node_type controller
+
+SCRIPT_PATH="/usr/local/sbin/sanitize-slurm-topology"
+SERVICE_PATH="/etc/systemd/system/sanitize-slurm-topology.service"
+PATH_UNIT_PATH="/etc/systemd/system/sanitize-slurm-topology.path"
+SLURM_CONF_WATCH="${SLURM_DIR:-/opt/slurm}/etc/slurm.conf"
+
+# The runtime script sources _lib.sh for sanitize_slurm_topology. It must NOT
+# source it from the lifecycle staging dir: SageMaker unpacks lifecycle scripts
+# under an ephemeral /tmp/<...>/lifecycle/<hash>/ path that is cleared on reboot
+# (and changes each lifecycle run), so a runtime script that sourced from there
+# would break after a controller reboot — exactly when a fresh slurmctld start
+# would re-hit the crash. Copy _lib.sh to a persistent path and source that.
+PERSIST_LIB="/usr/local/lib/physai/_lib.sh"
+STAGING_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_lib.sh"
+mkdir -p "$(dirname "$PERSIST_LIB")"
+cp "$STAGING_LIB" "$PERSIST_LIB"
+
+# The runtime script sources the persistent _lib.sh (for sanitize_slurm_topology)
+# and, if the fix changed anything, reconfigures. It resolves SLURM_DIR the same
+# way the orchestrator does — prefer /opt/slurm — so it edits the active install.
+cat > "$SCRIPT_PATH" << SCRIPT_EOF
+#!/bin/bash
+# Re-apply the HyperPod 25.11 topology workaround after the cluster agent
+# regenerates slurm.conf. Installed by install_topology_watcher.sh.
+set -eo pipefail
+if [ -e /opt/slurm ]; then
+    SLURM_DIR="\$(readlink -f /opt/slurm)"
+fi
+export SLURM_DIR="\${SLURM_DIR:-/opt/slurm}"
+# shellcheck source=/dev/null
+. "$PERSIST_LIB"
+if sanitize_slurm_topology; then
+    echo "sanitize-slurm-topology: config changed, reconfiguring slurmctld"
+    slurm_reconfigure_with_retry || echo "WARNING: reconfigure failed; see journal" >&2
+else
+    echo "sanitize-slurm-topology: nothing to change"
+fi
+SCRIPT_EOF
+chmod 0755 "$SCRIPT_PATH"
+
+# .service — oneshot. RemainAfterExit is NOT set: the .path unit only
+# re-triggers a service that is inactive when the next path event fires (same
+# reasoning as register_slurm_features.sh).
+cat > "$SERVICE_PATH" << EOF
+[Unit]
+Description=Re-apply HyperPod Slurm 25.11 topology workaround on slurm.conf change
+After=slurmctld.service
+
+[Service]
+Type=oneshot
+ExecStart=$SCRIPT_PATH
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# .path — fire on every write+close to slurm.conf (what the cluster agent does
+# when it regenerates the config).
+cat > "$PATH_UNIT_PATH" << EOF
+[Unit]
+Description=Watch slurm.conf and re-apply the topology workaround on change
+
+[Path]
+PathModified=$SLURM_CONF_WATCH
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+# enable (idempotent) then restart to pick up any updated unit/script content
+# on re-runs of this lifecycle script.
+systemctl enable sanitize-slurm-topology.path sanitize-slurm-topology.service
+systemctl restart sanitize-slurm-topology.path
+
+if systemctl is-active --quiet sanitize-slurm-topology.path; then
+    echo "sanitize-slurm-topology.path is active (watching $SLURM_CONF_WATCH)"
+else
+    echo "WARNING: sanitize-slurm-topology.path not active; check journalctl -u sanitize-slurm-topology.path" >&2
+fi

--- a/physai/infra/lifecycle/lifecycle_script.py
+++ b/physai/infra/lifecycle/lifecycle_script.py
@@ -120,6 +120,13 @@ def main():
     # 3. Start Slurm
     run("./start_slurm.sh", ",".join(controller_ips), env=env)
 
+    # 3b. Install the controller-side watcher that re-applies the HyperPod
+    #     Slurm 25.11 topology workaround whenever the cluster agent
+    #     regenerates slurm.conf (controller-only; self-guarded). start_slurm.sh
+    #     already applied it once before the first start; this keeps it applied
+    #     if the agent later rewrites slurm.conf.
+    run("./install_topology_watcher.sh", env=env)
+
     # 4. Install Docker + Enroot + Pyxis
     run("./install_docker.sh", env=env)
     run("./install_enroot_pyxis.sh", env=env)

--- a/physai/infra/lifecycle/start_slurm.sh
+++ b/physai/infra/lifecycle/start_slurm.sh
@@ -10,6 +10,14 @@ require_node_type controller compute login
 CONTROLLER_IPS="${1:?Usage: start_slurm.sh <controller_ips>}"
 
 if [[ "$NODE_TYPE" == "controller" ]]; then
+  # Sanitize the HyperPod Slurm 25.11 topology config BEFORE slurmctld's first
+  # start, so it starts cleanly instead of crash-looping on the generated config
+  # (see sanitize_slurm_topology in _lib.sh). At initial provision no scontrol
+  # reconfigure precedes this start, so a one-shot edit is sufficient here; the
+  # .path watcher (install_topology_watcher.sh) covers later agent
+  # regenerations. No-op when real topology is present or the config is clean.
+  sanitize_slurm_topology || true
+
   echo "Starting slurmctld (controller)..."
   systemctl enable --now slurmctld
   # Prevent slurmd from running on controller


### PR DESCRIPTION
## Purpose

Work around a HyperPod Slurm 25.11 topology configuration that crashes `slurmctld`
on the controller, so a cluster with a GPU worker group can provision.

## Changes

- `infra/lifecycle/_lib.sh` — add `sanitize_slurm_topology()`: remove the empty
  `topology.yaml`/`topology.conf` and strip the `Topology=` token from
  `PartitionName` lines. Guarded to no-op when real topology is configured
  (a `topology.conf` with `SwitchName=`/`BlockName=`, or a non-empty
  `topology.yaml`) so it never disables a topology-aware cluster.
- `infra/lifecycle/start_slurm.sh` — run it on the controller before slurmctld's
  first start (initial provision).
- `infra/lifecycle/install_topology_watcher.sh` (new) — install a systemd
  `.path` unit on `slurm.conf` that re-applies the fix and reconfigures whenever
  the cluster agent rewrites the file. Copies `_lib.sh` to a persistent path
  (`/usr/local/lib/physai/`) so it survives reboots.
- `infra/lifecycle/lifecycle_script.py` — register the watcher installer
  (controller-only; self-guarded).

Observed on the Slurm 25.11 AMI with a GPU worker group: `$SLURM_DIR/etc` contains
an empty `topology.yaml` (`[]`) + empty `topology.conf`, and the GPU
`PartitionName` carries a `Topology=tree` tag; with that config slurmctld
crash-loops on SIGSEGV and the controller never stays up (the visible
`No Assoc usage file` fatal is downstream). A 24.11 cluster on the same hardware
had none of these lines and was healthy. The trigger for the config is not
established (a deploy on 2026-06-29 succeeded), so this restores the
topology-free shape rather than diagnosing HyperPod's generation.

## Test Plan

**Environment:**

- AWS Service: SageMaker HyperPod (Slurm)
- Instance type: controller `ml.c5.large`, login `ml.c5.large`, GPU `ml.g6e.2xlarge`, CPU `ml.m5.2xlarge`
- Number of nodes: 4 (one per instance group)

**Test commands:**

```bash
cd physai/infra
AWS_REGION=ap-northeast-1 AWS_DEFAULT_REGION=ap-northeast-1 CDK_DEFAULT_REGION=ap-northeast-1 \
  npx cdk deploy PhysaiClusterStack --require-approval never --exclusively
```

## Test Results

Fresh `cdk deploy PhysaiClusterStack` from this branch on `ap-northeast-1`
(cluster `physai-cluster-37abf0f0`) reached **`CREATE_COMPLETE`** (HyperPod cluster resource
`CREATE_COMPLETE`, ~9 min).

Controller lifecycle log:

```
sanitize_slurm_topology: removing empty /opt/slurm/etc/topology.yaml
sanitize_slurm_topology: removing empty /opt/slurm/etc/topology.conf
sanitize_slurm_topology: stripping Topology= from PartitionName lines
sanitize_slurm_topology: applied HyperPod 25.11 topology workaround
Starting slurmctld (controller)...
Slurm started for controller
sanitize-slurm-topology.path is active (watching /opt/slurm/etc/slurm.conf)
...
Lifecycle setup complete
[SageMaker] The lifecycle scripts succeeded.
```

slurmctld started on the first attempt — no SIGSEGV, no `No Assoc usage file`,
no `Invalid partition topology`. Prior to this change the same deployment
crash-looped on the controller.

## Checklist

- [x] I am working against the latest `main` branch.
- [x] The contribution is self-contained.
- [x] No new external dependencies.
